### PR TITLE
Added OAuth to the extension

### DIFF
--- a/JS/background.js
+++ b/JS/background.js
@@ -1,0 +1,10 @@
+function getToken(sendResponse) {
+    chrome.identity.getAuthToken({interactive: true}, function(token) {
+	sendResponse(token);
+    });
+}
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    getToken(sendResponse)
+    return true;
+})

--- a/JS/inject.js
+++ b/JS/inject.js
@@ -7,6 +7,12 @@ class MessageData {
     }
 }
 
+var authorization_token;
+function saveToken(token) {
+	authorization_token  = token;
+}
+chrome.runtime.sendMessage('get_token',  saveToken);
+
 var lastSentVideo = "";
 var player,
     time_update_interval = 0;
@@ -357,8 +363,11 @@ document.querySelectorAll("." + joinBTNClass)[0].addEventListener("mouseup", fun
                 $.ajax({
                     type: 'GET',
                     url: 'https://www.googleapis.com/youtube/v3/search',
+		    headers: {
+			Authorization: 'Bearer ' + authorization_token,
+		    },
                     data: {
-                        key: 'AIzaSyCm4D3nwozwzixnDmDGU7Wj-8x0LSlyZ3g',
+			key: 'AIzaSyB9Q6dzIEP_l8ifEK8wDuO8dGWwFamNtKY',
                         q: string,
                         part: 'snippet',
                         maxResults: 10,

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
     "manifest_version":2,
     "name": "Studio 721",
     "version":"1",
+    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnqJ+rhNbn+ixZbQxAOcvx2AQUVqR07z+H7hrA1z1YGYpInsCZoAJ6D5/soqSYJCZdgD8stf9pYXrmyAs8yq286yRnUt7rYLTfzU9QfJzJMGSPUrjftuo6MMqpOeUlQYFraGt7INiEH2SiFekfgWkeydmoWx+niAHhkNCz9A7ccSyxGXlAjQEPe3y8xlkYOIjAyBaxTd8vTkereTxqtvUsmlzZj1i5UhORMbBOL4uv3XENffiPDhBNQm6bk2TZ481uZKgAp7UD63BqCViBhXblovquTdBJdbXlqmQmqsJC2hBcOUT6LJMHbe19yqAnfvSRJzrPBmpckevRfUstfYU0QIDAQAB",
     "content_scripts":[
         {
             "matches": ["*://*.meet.google.com/*"],
@@ -18,6 +19,13 @@
     },
     "browser_action":{
         "default_icon": "assets/icon.png"
-    }
+    },
+    "oauth2": {
+        "client_id": "794577565089-vl63fb4a2i618aed63448p153ns5629c.apps.googleusercontent.com",
+        "scopes":["https://www.googleapis.com/auth/youtube.readonly"]
+    },
+    "permissions": [
+      "identity"
+    ]
 }
 


### PR DESCRIPTION
The code in background gets the authentication token which is sent with the youtube search request through a modification of inject.js. Chrome messaging is used to connect the content to the background. In addition the extension was given a key to tie it to an Google API Application. This should change the id of the extension the next time it is loaded.

I am not certain that the OAuth user is going to solve the quote issue. The API key has been changed to tie it to the same account as the OAuth account. We will have to see. I can request a higher quota if required. Otherwise research on this will need to be done. However the OAuth code is useful for future features.

Closes #25 