### PR TITLE
Updated API_KEY and OAuth Client ID

### DIFF
--- a/JS/credentials.js
+++ b/JS/credentials.js
@@ -1,0 +1,9 @@
+const credentialsFile = chrome.runtime.getURL('/credentials.json');
+var credentials;
+
+fetch(credentialsFile)
+    .then(response => response.json())
+    .then((json) => {
+	credentials = json;
+	});
+

--- a/JS/inject.js
+++ b/JS/inject.js
@@ -570,7 +570,7 @@ document.querySelectorAll("." + joinBTNClass)[0].addEventListener("mouseup", fun
                             Authorization: 'Bearer ' + authorization_token,
                         },
                         data: {
-                            key: 'AIzaSyB9Q6dzIEP_l8ifEK8wDuO8dGWwFamNtKY',
+                            key: credentials['api_key'],
                             q: string,
                             part: 'snippet',
                             maxResults: 10,

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,5 @@
+{
+	"oauth_client_id": "877970995490-4k2309sla05klahjc420k23vpij4tvgj.apps.googleusercontent.com",
+	"api_key": "AIzaSyANa4tC3B7RQ2TAHmFtah39xbLose9dxwM"
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -20,15 +20,18 @@
         },
         {
             "matches": ["*://*.meet.google.com/*"],
-            "js":["JS/inject.js","JS/external/youtube.js"],
+            "js":["JS/credentials.js","JS/inject.js","JS/external/youtube.js"],
             "css":["CSS/inject.css"]
         }
     ],
     "background":{
         "scripts":["JS/background.js"]
     },
+    "web_accessible_resources": [
+        "credentials.json"
+    ],
     "oauth2": {
-        "client_id": "794577565089-vl63fb4a2i618aed63448p153ns5629c.apps.googleusercontent.com",
+        "client_id": "877970995490-4k2309sla05klahjc420k23vpij4tvgj.apps.googleusercontent.com",
         "scopes":["https://www.googleapis.com/auth/youtube.readonly"]
     },
     "permissions": [


### PR DESCRIPTION
The API_KEY and OAuth Client ID that were initially provided were from the wrong Google Project. In addition to providing new credentials this commit adds a credential file so that credentials can be updated without changing code files.

It should be noted that the OAuth Client ID is still directly embedded in the manifest.json. It is foreseen that a release project might change this behavior.

Closes #30 